### PR TITLE
feat: hack for checklists

### DIFF
--- a/src/webviewSrc/result/result.ts
+++ b/src/webviewSrc/result/result.ts
@@ -77,6 +77,10 @@ export class Result {
         return (this.level = level);
     }
 
+    public isChecklist(): boolean {
+        return this.sarifFile.getRule(this.ruleId)?.isChecklist ?? false;
+    }
+
     public getRule(): Rule {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return this.sarifFile.getRule(this.ruleId)!;

--- a/src/webviewSrc/result/resultDetailsWidget.ts
+++ b/src/webviewSrc/result/resultDetailsWidget.ts
@@ -181,7 +181,11 @@ export class ResultDetailsWidget {
 
             ruleDiv.appendChild(span0);
             ruleDiv.appendChild(div0);
-            appendRowToTable("Rule:", ruleDiv);
+            if (result.isChecklist()) {
+                appendRowToTable("Catalog:", ruleDiv);
+            } else {
+                appendRowToTable("Rule:", ruleDiv);
+            }
         }
 
         // Rule description
@@ -215,7 +219,7 @@ export class ResultDetailsWidget {
             pathElement.onclick = () => {
                 result.openPrimaryCodeRegion();
             };
-            appendRowToTable("Path:", pathElement);
+            if (!result.isChecklist()) appendRowToTable("Path:", pathElement);
         }
 
         // Data Flow

--- a/src/webviewSrc/result/resultsTableWidget.ts
+++ b/src/webviewSrc/result/resultsTableWidget.ts
@@ -692,7 +692,7 @@ export class ResultsTableWidget {
         }
 
         // Add the file column
-        {
+        if (!result.isChecklist()) {
             const cell = row.insertCell();
             cell.classList.add("resultPathCell");
             cell.innerText = displayPathAndLine;

--- a/src/webviewSrc/sarifFile/sarifFile.ts
+++ b/src/webviewSrc/sarifFile/sarifFile.ts
@@ -72,6 +72,7 @@ export class SarifFile {
 
                     toolName: this.tool.name,
                     isHidden: hiddenRules.includes(result.getRuleId()),
+                    isChecklist: false,
                 };
                 this.tool.rules.set(rule.id, rule);
             } else if (rule.level === ResultLevel.default) {
@@ -260,6 +261,9 @@ export class SarifFile {
 
                 // This level may be updated according to the level of a result with this rule
                 const level: ResultLevel = this.parseLevel(rule.defaultConfiguration?.level || "");
+
+                const isChecklist = rule.properties?.checklist == "true"|| false;
+
                 rules.set(ruleId, {
                     id: ruleId,
                     name: ruleName,
@@ -270,6 +274,7 @@ export class SarifFile {
                     helpURI: helpURI,
                     toolName: toolName,
                     isHidden: hiddenRules.includes(ruleId),
+                    isChecklist: isChecklist,
                 });
             }
         }


### PR DESCRIPTION
Adds `isChecklist` property on Rule which is set to true if `rule.properties.checklist` == "true".
Some display elements are conditionally changed if the result's rule is a checklist.

This change allows us to submit checklist catalog names as `Rules` in the run section and, checklist items as `results` below. This way we can maintain one static Sarif file as a repository for all checklist catalogs.

Here is an example Sarif for use with checklists and the new output.
 
<img width="1412" alt="image" src="https://github.com/trailofbits/vscode-sarif-explorer/assets/71567643/26c95c31-a507-45b7-b49f-fdaae9bd2726">
