### PR TITLE
ci: add publishing github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
 
 # We need to have write permissions to add the vsix to the release assets
 permissions:
-    contents: write
+    contents: read
 
 jobs:
     build:
@@ -26,6 +26,8 @@ jobs:
                   path: sarif-explorer.vsix
 
     publish:
+        permissions:
+            contents: write
         runs-on: ubuntu-latest
         needs: build
         if: success()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Build release and publish on VSCode's Marketplace and OpenVSX
+on:
+    release:
+        types: [published]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+
+            - name: Install dependencies
+              run: npm install
+
+            - name: Build the vsix
+              run: npx vsce package -o sarif-explorer.vsix
+
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: "sarif-explorer"
+                  path: "sarif-explorer.vsix"
+
+    publish:
+        runs-on: ubuntu-latest
+        needs: build
+        if: success()
+        steps:
+            - uses: actions/download-artifact@v4
+              with:
+                  name: "sarif-explorer"
+
+            # Uncomment the following lines to also publish the extension on the VSCode Marketplace
+            # - name: Publish Extension on VSCode's Marketplace
+            #   run: npx vsce publish --pat ${{ secrets.VSCODE_PUBLISHING_TOKEN }} --packagePath sarif-explorer.vsix
+
+            - name: Publish Extension on OpenVSX
+              run: npx ovsx publish --pat ${{ secrets.OPENVSX_PUBLISHING_TOKEN }} --packagePath sarif-explorer.vsix
+
+            - name: Add vsix to the release assets
+              uses: actions/upload-release-asset@v1.0.2
+              with:
+                  upload_url: ${{ github.event.release.upload_url }}
+                  asset_path: sarif-explorer.vsix
+                  asset_name: sarif-explorer.vsix
+                  asset_content_type: application/octet-stream
+                  token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ on:
     release:
         types: [published]
 
+# We need to have write permissions to add the vsix to the release assets
+permissions:
+    contents: write
+
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -18,8 +22,8 @@ jobs:
 
             - uses: actions/upload-artifact@v4
               with:
-                  name: "sarif-explorer"
-                  path: "sarif-explorer.vsix"
+                  name: sarif-explorer
+                  path: sarif-explorer.vsix
 
     publish:
         runs-on: ubuntu-latest
@@ -28,7 +32,7 @@ jobs:
         steps:
             - uses: actions/download-artifact@v4
               with:
-                  name: "sarif-explorer"
+                  name: sarif-explorer
 
             # Uncomment the following lines to also publish the extension on the VSCode Marketplace
             # - name: Publish Extension on VSCode's Marketplace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
 
             - name: Install dependencies
               run: npm install


### PR DESCRIPTION
This PR adds a publishing action that:

1. builds the vsix from the source code
2. uploads the vsix to open-vsx marketplace
3. uploads the vsix to the github release assets

Uploading to vscode's marketplace is currently commented out until we generate the personal access token for that.