### PR TITLE
Fix configuration separator title in settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sarif-explorer",
-    "version": "1.2.4",
+    "version": "1.2.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sarif-explorer",
-            "version": "1.2.4",
+            "version": "1.2.8",
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@vscode/codicons": "0.0.32"
@@ -3921,10 +3921,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
         ],
         "configuration": [
             {
-                "id": "general",
-                "title": "General Settings",
                 "order": 1,
                 "properties": {
                     "sarif-explorer.showFullPathInResultsTable": {


### PR DESCRIPTION
Prev: 
<img width="645" alt="image" src="https://github.com/user-attachments/assets/b9df9bbd-6683-45f7-9365-a0ffcb004811">

After:
<img width="629" alt="image" src="https://github.com/user-attachments/assets/51bd762c-d96a-46a7-99bb-15bfcd9054af">
