### PR TITLE
add check to optional location property of a result

### DIFF
--- a/src/webviewSrc/sarifFile/sarifFile.ts
+++ b/src/webviewSrc/sarifFile/sarifFile.ts
@@ -156,9 +156,11 @@ export class SarifFile {
 
             // Parse all the locations associated with the result
             const locations: ResultLocation[] = [];
-            for (const loc of result.locations) {
-                const parsedLocation: ResultLocation = this.parseLocation(loc);
-                locations.push(parsedLocation);
+            if (result.locations) {
+                for (const loc of result.locations) {
+                    const parsedLocation: ResultLocation = this.parseLocation(loc);
+                    locations.push(parsedLocation);
+                }
             }
 
             // See: https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10541098


### PR DESCRIPTION
### Update
Sorry, my git information was misconfigured on my development system. Closing this and opening a new pr so I can sign the CLA.

When attempting to open a SARIF report without any location properties, the process fails with the message
`Failed to load "test.sarif": Error: Parsing failed: TypeError: result.locations is not iterable.`
However, as noted in other parts of the codebase (i.e., [here](https://github.com/trailofbits/vscode-sarif-explorer/blob/ad5d110f60fc4d51edba3d5950ddfdf280e0cd78/src/webviewSrc/result/result.ts#L57)), locations are not required by the SARIF spec. 

This pull request adds a check to the location property of a deserialized SARIF report before attempting to iterate over it. I'm not sure if there are any other locations in the codebase that also need to be tweaked, but this fixed the issue for me. A minimized POC that led to this discovery is provided below. 

If there's anything I may have incorrectly assumed or overlooked, please let me know I'd be happy to contribute in any way I can!
```
{
  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
  "runs": [
    {
      "results": [
        {
          "level": "warning",
          "message": {
            "text": "Address Space Layout Randomization: None         "
          },
          "ruleId": "aslr"
        }
      ],
      "tool": {
        "driver": {
          "name": "checksec-anywhere"
        }
      }
    }
  ],
  "version": "2.1.0"
}
```