### PR TITLE
Support untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
             }
         ]
     },
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": true
+        }
+    },
     "scripts": {
         "vscode:prepublish": "npm run package",
         "vscode:package": "vsce package",


### PR DESCRIPTION
Currently, the extension is disabled for untrusted workspaces. However, since the extension neither executes code nor relies on the workspace files' content, it should be safe to activate the extension in untrusted workspaces.

Reference: https://code.visualstudio.com/api/extension-guides/workspace-trust#how-to-support-restricted-mode