### PR TITLE
fix: prevent cloberring a known basefolder when refreshing a file

### DIFF
--- a/src/extension/sarifExplorerWebview.ts
+++ b/src/extension/sarifExplorerWebview.ts
@@ -165,13 +165,25 @@ export class SarifExplorerWebview {
         return [path.dirname(sarifFilePath), ...Array.from(allOpenedBaseFolders)];
     }
 
+    // An empty base folder means "unknown", not "reset", so we recover any base folder we already
+    // know for this file. This happens when reopening a file without an explicit base folder (e.g.
+    // when refreshing the .sarif file, or opening it through the dialog)
+    private resolveKnownBaseFolder(sarifFilePath: string, baseFolder: string): string {
+        if (baseFolder !== "") {
+            return baseFolder;
+        }
+
+        return (
+            this._filesToOpen.get(sarifFilePath)?.baseFolder ||
+            this._openedSarifFiles.get(sarifFilePath)?.getBaseFolder() ||
+            this.getWorkspaceOpenedSarifFiles()[sarifFilePath]?.baseFolder ||
+            ""
+        );
+    }
+
     // To ensure the file is actually opened, you need to call `.show`
     public addSarifToToOpenList(sarifFilePath: string, baseFolder = ""): void {
-        if (baseFolder === "") {
-            // Reopening without an explicit base folder (e.g. refreshing the .sarif file) must not discard a known base folder
-            baseFolder = this._filesToOpen.get(sarifFilePath)?.baseFolder || this._openedSarifFiles.get(sarifFilePath)?.getBaseFolder() || "";
-        }
-        this._filesToOpen.set(sarifFilePath, { baseFolder: baseFolder });
+        this._filesToOpen.set(sarifFilePath, { baseFolder: this.resolveKnownBaseFolder(sarifFilePath, baseFolder) });
     }
 
     // Function that shows the webview panel
@@ -511,13 +523,7 @@ export class SarifExplorerWebview {
     }
 
     public openSarifFileAndSendToWebview(sarifFilePath: string, sarifFileWorkspaceData: SarifFileWorkspaceData): void {
-        // An empty base folder should not clobber a known one
-        if (sarifFileWorkspaceData.baseFolder === "") {
-            const previousMetadata = this._openedSarifFiles.get(sarifFilePath);
-            if (previousMetadata) {
-                sarifFileWorkspaceData = previousMetadata.getWorkspaceMetadata();
-            }
-        }
+        const baseFolder = this.resolveKnownBaseFolder(sarifFilePath, sarifFileWorkspaceData.baseFolder);
 
         // Open and send the SARIF file to the webview
         let res;
@@ -530,7 +536,7 @@ export class SarifExplorerWebview {
         }
 
         // Mark the file as opened
-        const sarifFileMetadata = new SarifFileMetadata(sarifFilePath, sarifFileWorkspaceData);
+        const sarifFileMetadata = new SarifFileMetadata(sarifFilePath, { ...sarifFileWorkspaceData, baseFolder: baseFolder });
         this._openedSarifFiles.set(sarifFilePath, sarifFileMetadata);
         // Update the data in the workspace storage
         void this.updateWorkspaceOpenedSarifFiles();

--- a/src/extension/sarifExplorerWebview.ts
+++ b/src/extension/sarifExplorerWebview.ts
@@ -167,6 +167,10 @@ export class SarifExplorerWebview {
 
     // To ensure the file is actually opened, you need to call `.show`
     public addSarifToToOpenList(sarifFilePath: string, baseFolder = ""): void {
+        if (baseFolder === "") {
+            // Reopening without an explicit base folder (e.g. refreshing the .sarif file) must not discard a known base folder
+            baseFolder = this._filesToOpen.get(sarifFilePath)?.baseFolder || this._openedSarifFiles.get(sarifFilePath)?.getBaseFolder() || "";
+        }
         this._filesToOpen.set(sarifFilePath, { baseFolder: baseFolder });
     }
 
@@ -507,6 +511,14 @@ export class SarifExplorerWebview {
     }
 
     public openSarifFileAndSendToWebview(sarifFilePath: string, sarifFileWorkspaceData: SarifFileWorkspaceData): void {
+        // An empty base folder should not clobber a known one
+        if (sarifFileWorkspaceData.baseFolder === "") {
+            const previousMetadata = this._openedSarifFiles.get(sarifFilePath);
+            if (previousMetadata) {
+                sarifFileWorkspaceData = previousMetadata.getWorkspaceMetadata();
+            }
+        }
+
         // Open and send the SARIF file to the webview
         let res;
         try {


### PR DESCRIPTION
The base folder associated with an open SARIF file was discarded whenever the
file was reopened without one being passed explicitly. Several call paths pass
an empty base folder by design:

- `onDidOpenTextDocument` in `extension.ts` — triggered by refreshing or
  re-opening the `.sarif` file in the editor
- the webview's `openSarifFile` message
- the "Open SARIF File" dialog

In each case the empty string overwrote the base folder already stored for that
file, so result paths stopped resolving until the user set the base folder again.