### PR TITLE
chore(deps): pin @types/vscode to the engines.vscode floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
+      # @types/vscode must not exceed engines.vscode, or we compile against API
+      # that is missing at runtime on the oldest VS Code we claim to support.
+      # Raise this together with engines.vscode, deliberately.
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@stylistic/eslint-plugin": "^5.10.0",
                 "@types/mocha": "^10.0.1",
                 "@types/node": "^24.13.3",
-                "@types/vscode": "^1.120.0",
+                "@types/vscode": "~1.120.0",
                 "@types/webpack": "^5.28.0",
                 "@typescript-eslint/eslint-plugin": "8.67.0",
                 "@typescript-eslint/parser": "8.67.0",
@@ -1507,9 +1507,9 @@
             "license": "MIT"
         },
         "node_modules/@types/vscode": {
-            "version": "1.125.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-            "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+            "version": "1.120.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+            "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "^24.13.3",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "~1.120.0",
         "@types/webpack": "^5.28.0",
         "@typescript-eslint/eslint-plugin": "8.67.0",
         "@typescript-eslint/parser": "8.67.0",


### PR DESCRIPTION
`@types/vscode` was ranged `^1.120.0` while `engines.vscode` is `^1.120.0`, so it was resolving to **1.125.0** — five minor versions of VS Code API ahead of what the extension promises to support at runtime. Any API added after 1.120 would typecheck cleanly and throw for users on VS Code 1.120–1.124.

This pins the types to the engine floor and tells Dependabot to stop proposing minor/major bumps for it, so the types only move when `engines.vscode` is raised deliberately.

### Changes

- `package.json`: `@types/vscode` `^1.120.0` → `~1.120.0` (resolves to 1.120.0; `~` leaves room for a future patch release)
- `.github/dependabot.yml`: ignore `version-update:semver-minor` and `semver-major` for `@types/vscode`, mirroring the existing `@types/node` rule

### Verification

Typecheck was the real test here — the codebase had been compiling against 1.125.0 types, so this would have failed if any post-1.120 API were in use. It doesn't:

```
tsc --noEmit                 exit 0
tsc -p . (compile-tests)     exit 0
eslint src                   exit 0
biome check (format)         exit 0
```

### Relation to #125

Dependabot's #125 proposes the opposite change (`^1.120.0` → `^1.134.0`, raising the declared floor to 1.134). That direction guarantees the mismatch rather than closing it. #125 should be closed in favour of this, unless the intent is to raise `engines.vscode` to 1.134 as well — which is a release decision about minimum supported VS Code, not a dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)