### PR TITLE
chore(deps-dev): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "style-loader": "4.0.0",
                 "ts-loader": "^9.6.2",
                 "ts-node": "^10.9.1",
-                "typescript": "^5.9.3",
+                "typescript": "~6.0.3",
                 "webpack": "^5.109.2",
                 "webpack-cli": "^7.2.2"
             },
@@ -7551,9 +7551,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "style-loader": "4.0.0",
         "ts-loader": "^9.6.2",
         "ts-node": "^10.9.1",
-        "typescript": "^5.9.3",
+        "typescript": "~6.0.3",
         "webpack": "^5.109.2",
         "webpack-cli": "^7.2.2"
     },

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import * as Mocha from "mocha";
+import Mocha from "mocha";
 import { glob } from "glob";
 
 export async function run(): Promise<void> {

--- a/src/webviewSrc/scss.d.ts
+++ b/src/webviewSrc/scss.d.ts
@@ -1,0 +1,4 @@
+// Type declarations for SCSS side-effect imports, which webpack resolves via sass-loader.
+// TypeScript 6 requires a declaration for every side-effect import.
+
+declare module "*.scss";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
         "sourceMap": true,
         "rootDir": "src",
         "strict": true,
+        "types": ["node"],
+        "esModuleInterop": true,
         "skipLibCheck": true
     }
 }


### PR DESCRIPTION
Dependabot's #127 proposes TypeScript 7.0.2, which cannot be installed: `@typescript-eslint` declares `peer typescript@">=4.8.4 <6.1.0"`, unchanged as of 8.68.0, so `npm install` fails with ERESOLVE before any check runs. 6.0.3 is the newest release inside that range.

Taking it now means the TS 6 breaking changes land while the linter still works, rather than arriving all at once alongside TS 7.

### Why `~6.0.3` and not `^6.0.3`

6.1.0 would fall outside typescript-eslint's peer ceiling, so a caret would silently resolve into a broken tree the moment 6.1 ships. The tilde keeps us in 6.0.x and makes the next move a visible range change.

### The TS 6 changes this required

- **`@types/*` are no longer auto-included** from `node_modulesut of the program, every Node API became `error`-typed, andtypescript-eslint's type-aware rules cascaded into 126 errors from that single root cause. Fixed with `types: ["node"]`, which is what the compiler's own diagnostic recommends.
- **A namespace import of a CommonJS module is no longer constr..)` failed. Fixed with `esModuleInterop` plus a default import.(`import Mocha = require("mocha")` also compiles, but trips `no-require-imports`.)
- **Side-effect imports need resolvable declarations**, so `imp a `declare module "*.scss"`.
