### PR TITLE
feat: display SARIF code snippets in the result details panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install the extension by searching for [SARIF Explorer](https://marketplace.visu
 ## Features
 
   - [**Open Multiple SARIF Files**](#open-multiple-sarif-files): Open and browse the results of multiple SARIF files simultaneously.
-  - [**Browse Results**](#browse-results): Browse results by clicking on them, which will open their associated location in VSCode. You can also browse a result's dataflow steps, if present.
+  - [**Browse Results**](#browse-results): Browse results by clicking on them, which will open their associated location in VSCode. You can also browse a result's dataflow steps and read the code snippets it points to, if present.
   - [**Classify Results**](#classify-results): Add metadata to each result by classifying them as a `Bug`, `False Positive`, or `Todo`, and adding a custom text comment.
   - [**Filter Results**](#filter-results): Filter results by keyword, path (to include or exclude), level (`error`, `warning`, `note`, or `none`), and status (`Bug`, `False Positive`, or `Todo`). You can also hide all results from a specific SARIF file or from a specific rule.
   - [**Copy GitHub Permalinks**](#copy-github-permalinks): Copy a GitHub permalink to the location associated with a result. Requires having [weAudit](https://github.com/trailofbits/vscode-weaudit) installed.

--- a/src/shared/resultTypes.ts
+++ b/src/shared/resultTypes.ts
@@ -31,6 +31,9 @@ export type LabeledLocation = {
 export type ResultLocation = {
     path: string;
     region: ResultRegion;
+
+    // The source code at this location, when the SARIF file provides it in `region.snippet.text`
+    snippet?: string;
 };
 
 export type ResultRegion = {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,6 +3,7 @@ import * as assert from "assert";
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from "vscode";
+import { dedentSnippet } from "../../webviewSrc/utils";
 // import * as myExtension from '../../extension';
 
 type VSCodeApi = {
@@ -247,5 +248,188 @@ suite("Extension Test Suite", () => {
         assert.strictEqual(results[1].getDescription(), "Full rule description");
         assert.strictEqual(results[2].getDescription(), "Only short rule description");
         assert.strictEqual(results[3].getDescription(), "");
+    });
+
+    test("Parses region snippets for all of a result's locations", async () => {
+        const sarifFileClass = await loadSarifFileClass();
+        const multiLineSnippet = "\t\tTLSClientConfig: &tls.Config{\n\t\t\tInsecureSkipVerify: true,\n\t\t},";
+        const sarifJson = {
+            version: "2.1.0",
+            runs: [
+                {
+                    tool: { driver: { name: "snippet-tool" } },
+                    results: [
+                        {
+                            ruleId: "snippet.rule",
+                            message: { text: "Result with snippets in every location" },
+                            locations: [
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/http.go" },
+                                        region: { startLine: 38, endLine: 40, snippet: { text: multiLineSnippet } },
+                                    },
+                                },
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/other.go" },
+                                        region: { startLine: 12, snippet: { text: "const x = 1;" } },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const sarifFile = new sarifFileClass("/tmp/snippets.sarif", JSON.stringify(sarifJson), {}, [], "");
+        const locations = sarifFile.getAllResults()[0].getLocations();
+
+        assert.strictEqual(locations.length, 2);
+        // The snippet is stored verbatim; it is only dedented when it is rendered
+        assert.strictEqual(locations[0].snippet, multiLineSnippet);
+        assert.strictEqual(locations[1].snippet, "const x = 1;");
+    });
+
+    test("Leaves the snippet undefined when the SARIF file provides no snippet text", async () => {
+        const sarifFileClass = await loadSarifFileClass();
+        const sarifJson = {
+            version: "2.1.0",
+            runs: [
+                {
+                    tool: { driver: { name: "snippet-less-tool" } },
+                    results: [
+                        {
+                            ruleId: "snippet.rule",
+                            message: { text: "Result without usable snippets" },
+                            locations: [
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/no_snippet.go" },
+                                        region: { startLine: 1 },
+                                    },
+                                },
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/empty_snippet_object.go" },
+                                        region: { startLine: 2, snippet: {} },
+                                    },
+                                },
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/empty_snippet_text.go" },
+                                        region: { startLine: 3, snippet: { text: "" } },
+                                    },
+                                },
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/non_string_snippet_text.go" },
+                                        region: { startLine: 4, snippet: { text: { unexpected: true } } },
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const sarifFile = new sarifFileClass("/tmp/no-snippets.sarif", JSON.stringify(sarifJson), {}, [], "");
+        const locations = sarifFile.getAllResults()[0].getLocations();
+
+        assert.strictEqual(locations.length, 4);
+        for (const location of locations) {
+            assert.strictEqual(location.snippet, undefined, `Unexpected snippet for ${location.path}`);
+        }
+    });
+
+    test("Parses snippets on related locations and data flow steps", async () => {
+        const sarifFileClass = await loadSarifFileClass();
+        const sarifJson = {
+            version: "2.1.0",
+            runs: [
+                {
+                    tool: { driver: { name: "snippet-flow-tool" } },
+                    results: [
+                        {
+                            ruleId: "snippet.flow.rule",
+                            message: { text: "Result with a data flow" },
+                            locations: [
+                                {
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/sink.go" },
+                                        region: { startLine: 30, snippet: { text: "sink(taint);" } },
+                                    },
+                                },
+                            ],
+                            relatedLocations: [
+                                {
+                                    id: 1,
+                                    message: { text: "related" },
+                                    physicalLocation: {
+                                        artifactLocation: { uri: "src/related.go" },
+                                        region: { startLine: 7, snippet: { text: "related(code);" } },
+                                    },
+                                },
+                            ],
+                            codeFlows: [
+                                {
+                                    threadFlows: [
+                                        {
+                                            locations: [
+                                                {
+                                                    location: {
+                                                        message: { text: "source" },
+                                                        physicalLocation: {
+                                                            artifactLocation: { uri: "src/source.go" },
+                                                            region: { startLine: 10, snippet: { text: "taint = source();" } },
+                                                        },
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const sarifFile = new sarifFileClass("/tmp/snippet-flow.sarif", JSON.stringify(sarifJson), {}, [], "");
+        const result = sarifFile.getAllResults()[0];
+
+        assert.strictEqual(result.getRelatedLocations().get(1)?.location.snippet, "related(code);");
+        assert.strictEqual(result.getDataFlow()[0].location.snippet, "taint = source();");
+    });
+
+    test("dedentSnippet removes the indentation shared by all non-blank lines", () => {
+        // Space indentation
+        assert.strictEqual(dedentSnippet("    if (a) {\n        b();\n    }"), "if (a) {\n    b();\n}");
+
+        // Tab indentation, as emitted by Semgrep for Go files
+        assert.strictEqual(
+            dedentSnippet("\t\tTLSClientConfig: &tls.Config{\n\t\t\tInsecureSkipVerify: true,\n\t\t},"),
+            "TLSClientConfig: &tls.Config{\n\tInsecureSkipVerify: true,\n},",
+        );
+
+        // A blank line in the middle does not prevent dedenting
+        assert.strictEqual(dedentSnippet("    a();\n\n    b();"), "a();\n\nb();");
+
+        // Nothing to strip
+        assert.strictEqual(dedentSnippet("a();"), "a();");
+        assert.strictEqual(dedentSnippet("a();\n    b();"), "a();\n    b();");
+
+        // Mixed tabs and spaces are compared literally, so only the common prefix is stripped
+        assert.strictEqual(dedentSnippet("\t a();\n\t\tb();"), " a();\n\tb();");
+
+        // Trailing blank lines are dropped
+        assert.strictEqual(dedentSnippet("    a();\n"), "a();");
+        assert.strictEqual(dedentSnippet("    a();\n    \n\n"), "a();");
+
+        // Snippets with no code at all
+        assert.strictEqual(dedentSnippet(""), "");
+        assert.strictEqual(dedentSnippet("   \n  \n"), "");
     });
 });

--- a/src/webviewSrc/result/result.ts
+++ b/src/webviewSrc/result/result.ts
@@ -190,7 +190,11 @@ export class Result {
     }
 
     public getResultNormalizedPath(): string {
-        return normalizePath(this.getResultPath(), this.sarifFile.getResultsBaseFolder());
+        return this.getLocationNormalizedPath(this.getResultPrimaryLocation());
+    }
+
+    public getLocationNormalizedPath(location: ResultLocation): string {
+        return normalizePath(location.path, this.sarifFile.getResultsBaseFolder());
     }
 
     public getRelatedLocations(): Map<number, LabeledLocation> {

--- a/src/webviewSrc/result/resultDetailsWidget.ts
+++ b/src/webviewSrc/result/resultDetailsWidget.ts
@@ -1,6 +1,6 @@
 import { ResultAndRow } from "./result";
 import { ResultsTableWidget } from "./resultsTableWidget";
-import { getElementByIdOrThrow } from "../utils";
+import { dedentSnippet, getElementByIdOrThrow } from "../utils";
 import { ResultLocation } from "../../shared/resultTypes";
 
 export class ResultDetailsWidget {
@@ -280,6 +280,39 @@ export class ResultDetailsWidget {
                 result.openPrimaryCodeRegion();
             };
             appendRowToTable("Path:", pathElement);
+        }
+
+        // Snippet
+        {
+            const snippets: { location: ResultLocation; snippet: string }[] = [];
+            for (const location of result.getLocations()) {
+                if (location.snippet !== undefined) {
+                    snippets.push({ location: location, snippet: location.snippet });
+                }
+            }
+
+            if (snippets.length > 0) {
+                const snippetsDiv = document.createElement("div");
+
+                for (const { location, snippet } of snippets) {
+                    // With a single snippet, a label would just repeat the "Path:" row above it
+                    if (snippets.length > 1) {
+                        const labelDiv = document.createElement("div");
+                        labelDiv.classList.add("secondaryText");
+                        labelDiv.classList.add("detailCodeSnippetLabel");
+                        labelDiv.innerText = result.getLocationNormalizedPath(location) + ":" + location.region.startLine.toString();
+                        snippetsDiv.appendChild(labelDiv);
+                    }
+
+                    const snippetElement = document.createElement("pre");
+                    snippetElement.classList.add("detailCodeSnippet");
+                    // A snippet is untrusted tool output, so we set it as text and never as HTML
+                    snippetElement.textContent = dedentSnippet(snippet);
+                    snippetsDiv.appendChild(snippetElement);
+                }
+
+                appendRowToTable("Snippet:", snippetsDiv);
+            }
         }
 
         // Data Flow

--- a/src/webviewSrc/sarifFile/sarifFile.ts
+++ b/src/webviewSrc/sarifFile/sarifFile.ts
@@ -145,7 +145,7 @@ export class SarifFile {
             path = "";
         }
 
-        return {
+        const parsedLocation: ResultLocation = {
             path: path,
             region: {
                 startLine: loc.physicalLocation?.region?.startLine || 1,
@@ -154,6 +154,14 @@ export class SarifFile {
                 endColumn: loc.physicalLocation?.region?.endColumn || loc.physicalLocation?.region?.startColumn + 1 || 10000,
             },
         };
+
+        // A region MAY contain a property named snippet whose value is an artifactContent object with the code at this region
+        const snippet = this.parseText(loc.physicalLocation?.region?.snippet?.text);
+        if (snippet !== "") {
+            parsedLocation.snippet = snippet;
+        }
+
+        return parsedLocation;
     }
 
     // Parse a list of json results and return a list of Result objects

--- a/src/webviewSrc/style.scss
+++ b/src/webviewSrc/style.scss
@@ -458,6 +458,27 @@ table {
     resize: vertical;
 }
 
+.detailCodeSnippet {
+    // top | right | bottom | left
+    margin: 0 0 4px 0;
+    padding: 4px 6px;
+    border-radius: 3px;
+
+    background-color: var(--vscode-textCodeBlock-background);
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-editor-font-size);
+
+    // The details table has a fixed layout, so a snippet scrolls instead of widening the panel
+    white-space: pre;
+    overflow-x: auto;
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.detailCodeSnippetLabel {
+    font-size: 0.9em;
+}
+
 #resultDetailsPanel {
     .rowButtons {
         display: flex;

--- a/src/webviewSrc/utils.ts
+++ b/src/webviewSrc/utils.ts
@@ -9,3 +9,42 @@ export function getElementByIdOrThrow(id: string): HTMLElement {
 export function scrollToRow(row: HTMLElement): void {
     row.scrollIntoView({ block: "nearest", inline: "center" });
 }
+
+// Removes the whitespace prefix shared by all non-blank lines of a code snippet, as well as its trailing blank lines.
+// SARIF snippets include the indentation the code has in the original file, which wastes horizontal space when rendered.
+export function dedentSnippet(snippet: string): string {
+    const lines = snippet.split("\n");
+
+    // Drop the trailing blank lines
+    while (lines.length > 0 && lines[lines.length - 1].trim() === "") {
+        lines.pop();
+    }
+
+    // Find the longest whitespace prefix shared by every non-blank line. Prefixes are compared literally so that we
+    // never guess a tab width for snippets that mix tabs and spaces.
+    let commonIndentation: string | undefined = undefined;
+    for (const line of lines) {
+        if (line.trim() === "") {
+            continue;
+        }
+
+        const indentation = line.match(/^[ \t]*/)![0];
+        if (commonIndentation === undefined) {
+            commonIndentation = indentation;
+            continue;
+        }
+
+        let i = 0;
+        while (i < commonIndentation.length && i < indentation.length && commonIndentation[i] === indentation[i]) {
+            i++;
+        }
+        commonIndentation = commonIndentation.substring(0, i);
+    }
+
+    if (commonIndentation === undefined || commonIndentation === "") {
+        return lines.join("\n");
+    }
+
+    const indentationToRemove = commonIndentation;
+    return lines.map((line): string => (line.trim() === "" ? "" : line.substring(indentationToRemove.length))).join("\n");
+}


### PR DESCRIPTION
SARIF results may embed the offending source in `region.snippet.text`, but `parseLocation` discarded it. Keep it on `ResultLocation` and render one read-only code block per location that has one, right below the "Path:" row.

Snippets carry the indentation they have in the original file, so they are dedented before being rendered.

<img width="844" height="232" alt="image" src="https://github.com/user-attachments/assets/c450a35e-d15b-4ddb-81d7-1eefc5211990" />

Closes #129