### PR TITLE
ci: trigger the release on a tag push and gate publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: Build release and publish on VSCode's Marketplace and OpenVSX
 on:
-    release:
-        types: [published]
+    push:
+        tags:
+            - "v*"
 
 permissions:
     contents: read
@@ -29,7 +30,7 @@ jobs:
                   name: sarif-explorer
                   path: sarif-explorer.vsix
 
-    upload-asset:
+    create-release:
         runs-on: ubuntu-latest
         needs: build
         if: success()
@@ -40,20 +41,18 @@ jobs:
               with:
                   name: sarif-explorer
 
-            - name: Add vsix to the release assets
-              uses: actions/upload-release-asset@v1.0.2
+            - name: Create the release with the vsix attached
+              run: gh release create "$TAG" sarif-explorer.vsix --generate-notes --verify-tag
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  upload_url: ${{ github.event.release.upload_url }}
-                  asset_path: sarif-explorer.vsix
-                  asset_name: sarif-explorer.vsix
-                  asset_content_type: application/octet-stream
+                  TAG: ${{ github.ref_name }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
 
     publish:
         runs-on: ubuntu-latest
-        needs: build
+        needs: create-release
         if: success()
+        environment: marketplace
         steps:
             - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:

--- a/README.md
+++ b/README.md
@@ -170,3 +170,7 @@ The extension has two parts: the extension--the privileged part that can read fi
 ### SARIF Explorer file format
 
 The SARIF explorer file format is detailed in [sarif_explorer_spec.md](./docs/sarif_explorer_spec.md).
+
+### Releasing
+
+The release process is detailed in [releasing.md](./docs/releasing.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,25 @@
+# Releasing SARIF Explorer
+
+A release is created by pushing a `v*` tag. The [publish workflow](../.github/workflows/publish.yml) builds the vsix, creates the GitHub release with the vsix attached, and publishes the extension to the VSCode Marketplace and to OpenVSX.
+
+1. Merge a PR that bumps `version` in `package.json`, running `npm install` to carry the version into `package-lock.json`.
+
+2. Tag the bump commit on `main` and push the tag:
+
+   ```bash
+   VERSION=v?.?.?
+
+   git checkout main && git pull
+   git tag "$VERSION"
+   git push origin "$VERSION"
+   ```
+
+3. Approve the deployment on the workflow run. The `publish` job waits for a reviewer, so nothing
+   reaches the Marketplace or OpenVSX until it is approved.
+
+Do not create the release through the GitHub web UI. Releases in this repository are immutable, so
+the vsix cannot be attached after the release is published.
+
+If the Marketplace step fails with `Access Denied: The Personal Access Token used has expired`,
+`VSCODE_PUBLISHING_TOKEN` needs a new [Azure DevOps](https://dev.azure.com) token with the
+`Marketplace > Manage` scope. They are capped at one year.


### PR DESCRIPTION
Attaching the vsix to an already published release stopped working once immutable releases were enabled on the repository. `gh release create` uploads the asset while the release is still a draft and publishes it afterwards, which stays within the window where assets can be attached.

The release is now cut by pushing a v* tag rather than by publishing a release through the web UI, and the Marketplace and OpenVSX step runs in the `marketplace` environment so it waits for a reviewer. That step also no longer starts before the release exists: it used to declare the same `needs: build` as the asset upload, so it published to the Marketplace in parallel even when attaching the vsix had failed.